### PR TITLE
Enable compressed keys tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ var ecdsa = new ECDSA(ecparams);
 //ECDSA.ecparams = ecparams;
 
 var pubPoint = ecparams.getG().multiply(privKey)
-var pubKey = pubPoint.getEncoded(false) //true => compressed, fails though, must investigate
+var pubKey = pubPoint.getEncoded(false) //true => compressed
 var msg = "hello world!"
 var shaMsg = sha256(msg)
 var signature = ecdsa.sign(shaMsg, privKey)

--- a/test/ecdsa.test.js
+++ b/test/ecdsa.test.js
@@ -24,7 +24,7 @@ describe('- verify()', function() {
       var ecdsa = new ECDSA(ecparams);
       //var privKey = ecdsa.getBigRandom(ecparams.getN())
       var pubPoint = ecparams.getG().multiply(privKey)
-      var pubKey = pubPoint.getEncoded(false) //true => compressed, test fails then, must investigate
+      var pubKey = pubPoint.getEncoded(false) //true => compressed
       var msg = "hello world!"
       var shaMsg = sha256(msg)
       var signature = ecdsa.sign(shaMsg, privKey)
@@ -60,7 +60,7 @@ describe('+ verify()', function() {
       ECDSA.ecparams = ecparams;
       //var privKey = ecdsa.getBigRandom(ecparams.getN())
       var pubPoint = ecparams.getG().multiply(privKey)
-      var pubKey = pubPoint.getEncoded(false) //true => compressed, test fails then, must investigate
+      var pubKey = pubPoint.getEncoded(false) //true => compressed
       var msg = "hello world!"
       var shaMsg = sha256(msg)
       var signature = ECDSA.sign(shaMsg, privKey)


### PR DESCRIPTION
They now work, after applying https://github.com/cryptocoinjs/ecurve/pull/8
