### PR TITLE
attachECParams: use bind() instead of inline functions

### DIFF
--- a/lib/ecdsa.js
+++ b/lib/ecdsa.js
@@ -18,15 +18,14 @@ var util = require('./util')
 // crypto currencies use
 module.exports = (function(){
   var _ecparams = ecurve.getECParams('secp256k1')
+  var methods = {calcPubKeyRecoveryParam: calcPubKeyRecoveryParam, deterministicGenerateK: deterministicGenerateK,
+                 recoverPubKey: recoverPubKey, sign: sign, verify: verify, verifyRaw: verifyRaw}
 
   function attachECParams(ecdsa, ecparams) {
-    //attach ecparams functions, remember, almost everyone will be using secp256k1
-    ecdsa.calcPubKeyRecoveryParam = function() { var args = [].slice.call(arguments); args.unshift(ecparams); return calcPubKeyRecoveryParam.apply(null, args)}
-    ecdsa.deterministicGenerateK = function() { var args = [].slice.call(arguments); args.unshift(ecparams); return deterministicGenerateK.apply(null, args)}
-    ecdsa.recoverPubKey = function() { var args = [].slice.call(arguments); args.unshift(ecparams); return recoverPubKey.apply(null, args)}
-    ecdsa.sign = function() { var args = [].slice.call(arguments); args.unshift(ecparams); return sign.apply(null, args)}
-    ecdsa.verify = function() { var args = [].slice.call(arguments); args.unshift(ecparams); return verify.apply(null, args)}
-    ecdsa.verifyRaw = function() { var args = [].slice.call(arguments); args.unshift(ecparams); return verifyRaw.apply(null, args)}
+    // attach ecparams functions, remember, almost everyone will be using secp256k1
+    Object.keys(methods).forEach(function(method) {
+      ecdsa[method] = methods[method].bind(null, ecparams);
+    })
   }
 
   function _ecdsa(curveName) {


### PR DESCRIPTION
Using `bind()` is much more elegant and shorter than the current block of inline functions, but `bind` is somewhat slower than the current implementation.

I think that in this case its worth optimizing for readability rather than for CPU time. What do you think?
