### PR TITLE
Deprecation notice: Fixes #21 #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+Deprecated
+==========
+
+Please use [`elliptic`](https://github.com/indutny/elliptic) (<https://github.com/indutny/elliptic>) instead.
+
 ecdsa
 ======
 


### PR DESCRIPTION
Added this:

```
Deprecated
==========

Please use [`elliptic`](https://github.com/indutny/elliptic) (<https://github.com/indutny/elliptic>) instead.
```
